### PR TITLE
[DA-256][DA-257] Rework support for collections and scopes to allow multiple scopes and collections to be used

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Test where query
         uses: ./.github/actions/test-action
         with:
-          graphql-input: '{inventory_airport_airport(where:{country:{_eq:\"United States\"}},limit:10){airportname}'
+          graphql-input: '{inventory_airport_airport(where:{country:{_eq:\"United States\"}},limit:10){airportname}}'
           graphql-object-path: '.data.inventory_airport_airport'
           n1q1-input: 'SELECT airportname AS airportname FROM `travel-sample`.`inventory`.`airport` AS airport WHERE type = \"airport\" AND airport.`country` = \"United States\" LIMIT 10'
           n1q1-object-path: '.results'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -41,14 +41,21 @@ jobs:
       - name: Test basic query
         uses: ./.github/actions/test-action
         with:
-          graphql-input: "{Airline(limit: 10){country}}"
-          graphql-object-path: '.data.Airline'
+          graphql-input: "{inventory_airport_airport(limit: 10){country}}"
+          graphql-object-path: '.data.inventory_airport_airport'
           n1q1-input: 'SELECT country AS country FROM `travel-sample`.`inventory`.`airline` AS airline WHERE type = \"airline\" LIMIT 10'
+          n1q1-object-path: '.results'
+      - name: Test query from a different scope and collection
+        uses: ./.github/actions/test-action
+        with:
+          graphql-input: "{inventory_landmark_landmark(limit: 10){activity}}"
+          graphql-object-path: '.data.inventory_landmark_landmark'
+          n1q1-input: 'SELECT activity AS activity FROM `travel-sample`.`inventory`.`landmark` AS landmark WHERE type = "landmark" LIMIT 10'
           n1q1-object-path: '.results'
       - name: Test aggregate query
         uses: ./.github/actions/test-action
         with:
-          graphql-input: "{Airline_aggregate{aggregate{count(distinct: false, column: country)}}}"
-          graphql-object-path: '.data.Airline_aggregate.aggregate.count'
+          graphql-input: "{inventory_airport_airport_aggregate{aggregate{count(distinct: false, column: country)}}}"
+          graphql-object-path: '.data.inventory_airport_airport_aggregate.aggregate.count'
           n1q1-input: 'SELECT COUNT(`country`) AS aggregate_count FROM `travel-sample`.`inventory`.`airline` AS airline WHERE type = \"airline\"'
           n1q1-object-path: '.results[0].aggregate_count'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -57,7 +57,7 @@ jobs:
         with:
           graphql-input: "{inventory_airport_airport_aggregate{aggregate{count(distinct: false, column: country)}}}"
           graphql-object-path: '.data.inventory_airport_airport_aggregate.aggregate.count'
-          n1q1-input: 'SELECT COUNT(`country`) AS aggregate_count FROM `travel-sample`.`inventory`.`airline` AS airline WHERE type = \"airline\"'
+          n1q1-input: 'SELECT COUNT(`country`) AS aggregate_count FROM `travel-sample`.`inventory`.`airport` AS airport WHERE type = \"airport\"'
           n1q1-object-path: '.results[0].aggregate_count'
       - name: Test where query
         uses: ./.github/actions/test-action

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           graphql-input: "{inventory_landmark_landmark(limit: 10){activity}}"
           graphql-object-path: '.data.inventory_landmark_landmark'
-          n1q1-input: 'SELECT activity AS activity FROM `travel-sample`.`inventory`.`landmark` AS landmark WHERE type = "landmark" LIMIT 10'
+          n1q1-input: 'SELECT activity AS activity FROM `travel-sample`.`inventory`.`landmark` AS landmark WHERE type = \"landmark\" LIMIT 10'
           n1q1-object-path: '.results'
       - name: Test aggregate query
         uses: ./.github/actions/test-action

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           graphql-input: "{inventory_airport_airport(limit: 10){country}}"
           graphql-object-path: '.data.inventory_airport_airport'
-          n1q1-input: 'SELECT country AS country FROM `travel-sample`.`inventory`.`airline` AS airline WHERE type = \"airline\" LIMIT 10'
+          n1q1-input: 'SELECT country AS country FROM `travel-sample`.`inventory`.`airport` AS airport WHERE type = \"airport\" LIMIT 10'
           n1q1-object-path: '.results'
       - name: Test query from a different scope and collection
         uses: ./.github/actions/test-action
@@ -59,3 +59,10 @@ jobs:
           graphql-object-path: '.data.inventory_airport_airport_aggregate.aggregate.count'
           n1q1-input: 'SELECT COUNT(`country`) AS aggregate_count FROM `travel-sample`.`inventory`.`airline` AS airline WHERE type = \"airline\"'
           n1q1-object-path: '.results[0].aggregate_count'
+      - name: Test where query
+        uses: ./.github/actions/test-action
+        with:
+          graphql-input: '{inventory_airport_airport(where:{country:{_eq:\"United States\"}},limit:10){airportname}'
+          graphql-object-path: '.data.inventory_airport_airport'
+          n1q1-input: 'SELECT airportname AS airportname FROM `travel-sample`.`inventory`.`airport` AS airport WHERE type = \"airport\" AND airport.`country` = \"United States\" LIMIT 10'
+          n1q1-object-path: '.results'

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -1,5 +1,3 @@
-
-
 # Data Connectors
 
 This document describes the specification of the DC Couchbase Agent that needs to be used with the new feature (data connectors from Hasura `graphql-engine`, which is under active development)
@@ -25,11 +23,11 @@ cp .env.example .env
 Start an instance of Couchbase and Hasura Graphql Engine (HGE, with the
 experimental feature) to allow the DC agent and HGE to connect.
 
-``` sh
+```sh
 docker-compose up --build -d
 ```
 
-The username and password to connect to the Couchbase Cluster can be found in the docker-compose.yml file.  The couchbase-server will automatically start up, create a cluster with the provided username and password, and load the `travel-sample` bucket.
+The username and password to connect to the Couchbase Cluster can be found in the docker-compose.yml file. The couchbase-server will automatically start up, create a cluster with the provided username and password, and load the `travel-sample` bucket.
 
 The table should now be available in the GraphiQL console. By default this is hosted at `localhost:8080`. You should be able to issue queries via the web service. For example:
 
@@ -49,7 +47,7 @@ query {
 
 # Using CLI
 
-Once an agent is running, edit the following metadata located in `@/opt/couchbase/init/metadata.json` and import it into `graphql-engine` using the the Docker terminal for couchbase-server using the command: 
+Once an agent is running, edit the following metadata located in `@/opt/couchbase/init/metadata.json` and import it into `graphql-engine` using the the Docker terminal for couchbase-server using the command:
 
 ```sh
   /opt/couchbase/bin/curl -v -d "@/opt/couchbase/init/metadata.json" http://hasura:8080/v1/metadata
@@ -63,7 +61,7 @@ The `name` property under the source will be sent to the agent on every request 
 
 The `kind` property under the source should be the name of the dataconnector defined under backend_configs, in this case `couchbase`
 
-The `tables` property defines the tables that are tracked with Hasura.
+The `tables` property defines the tables that are tracked with Hasura. You can add these in the form `["scopeName", "collectionName", "documentFlavorType"]`
 
 The `configuration.value` property defines the Couchbase database. Fill in the values with the details of your Couchbase database. `scope` and `collection` will default to `_default` if left undefined.
 
@@ -87,10 +85,20 @@ The `configuration.value` property defines the Couchbase database. Fill in the v
         {
           "name": "couchbase",
           "kind": "couchbase",
-          "tables": [ 
+          "tables": [
+            // List of tables to track through Hasura
             {
-              "table": "Airline", // Collections to be tracked by HGE
-              "object_relationships": []
+              "table": [
+                "_default", // scope
+                "_default", // collection
+                "hotel" // document flavor
+              ]
+            },
+            {
+              "table": ["inventory", "airport", "airport"]
+            },
+            {
+              "table": ["inventory", "landmark", "landmark"]
             }
           ],
           "configuration": {
@@ -111,19 +119,22 @@ The `configuration.value` property defines the Couchbase database. Fill in the v
 ```
 
 # Using UI
+
 You can also setup the agent through the Hasura UI hosted by default at `http://localhost:8080/console`
 
 # Data
-The Couchbase data connector should be already set up by default under the Data tab on the console. 
+
+The Couchbase data connector should be already set up by default under the Data tab on the console.
 
 To add more databases, click connect database on the Data tab and select `couchbase`. Fill out the configuration with your Couchbase database details and click `Connect Database`.
 
-By default, the tables in your newly added database will be untracked and you will not be able to start querying by default. To track tables, click View Database, and click track under the Table.
+By default, some tables in your newly added database will be untracked and you will not be able to start querying them by default. We have tracked the hotel, airport, and landmark tables. To track more tables, click View Database, and click track under the Table.
 
 # Metadata
-You can import and export the metadata through the Settings icon on the console. For example
 
-```
+You can import and export the metadata through the Settings icon on the console, by clicking and copy pasting the metadata into the input box. This is our metadata:
+
+```json
 {
   "version": 3,
   "backend_configs": {
@@ -137,10 +148,20 @@ You can import and export the metadata through the Settings icon on the console.
     {
       "name": "couchbase",
       "kind": "couchbase",
-      "tables": [ 
+      "tables": [
+        // List of tables to track through Hasura
         {
-          "table": "Airline", // Collections to be tracked by HGE
-          "object_relationships": []
+          "table": [
+            "_default", // scope
+            "_default", // collection
+            "hotel" // document flavor
+          ]
+        },
+        {
+          "table": ["inventory", "airport", "airport"]
+        },
+        {
+          "table": ["inventory", "landmark", "landmark"]
         }
       ],
       "configuration": {

--- a/couchbase-server/metadata.json
+++ b/couchbase-server/metadata.json
@@ -17,20 +17,13 @@
         {
           "name": "couchbase",
           "kind": "couchbase",
-          "tables": [
-            {
-              "table": "Airline",
-              "object_relationships": []
-            }
-          ],
+          "tables": [],
           "configuration": {
             "value": {
               "db": "db1",
               "username": "Administrator",
               "password": "Passw0rd$12",
-              "bucket": "travel-sample",
-              "scope": "inventory",
-              "collection": "airline"
+              "bucket": "travel-sample"
             }
           }
         }

--- a/couchbase-server/metadata.json
+++ b/couchbase-server/metadata.json
@@ -17,7 +17,29 @@
         {
           "name": "couchbase",
           "kind": "couchbase",
-          "tables": [],
+          "tables": [
+            {
+              "table": [
+                "_default",
+                "_default",
+                "hotel"
+              ]
+            },
+            {
+              "table": [
+                "inventory",
+                "airport",
+                "airport"
+              ]
+            },
+            {
+              "table": [
+                "inventory",
+                "landmark",
+                "landmark"
+              ]
+            }
+          ],
           "configuration": {
             "value": {
               "db": "db1",

--- a/src/config.ts
+++ b/src/config.ts
@@ -16,8 +16,6 @@ export type Config = {
   db: string,
   username: string,
   password: string,
-  scope: string | '_default',
-  collection: string  | '_default',
   documents:  Document[] | null, 
   healtCheckStrategy: 'ping' | 'diagnostic' | null,
 }
@@ -56,8 +54,6 @@ export const tryGetConfig = (request: FastifyRequest): Config | null => {
     db: config.db,
     username: config.username,
     password: config.password,
-    scope: config.scope ?? '_default',
-    collection: config.collection ?? '_default',
     healtCheckStrategy: config.healtCheckStrategy,
     documents: config.documents,
   }
@@ -84,17 +80,6 @@ export const configSchema: ConfigSchemaResponse = {
       bucket: {
         description: "The Couchbase bucket.",
         type: "string"
-      },
-      scope: {
-        description: "Scope of collections",
-        type: "string",
-        default: "_default",
-      },
-      collection: {
-        description: "Collection to make available in the schema and for querying",
-        type: "string",
-        default: "_default",
-        nullable: true
       },
       documents: {
         description: "A list of documents and the relations allowed",

--- a/src/query.ts
+++ b/src/query.ts
@@ -56,7 +56,7 @@ function escapeIdentifier(identifier: string): string {
  * @returns tableName
  */
 function validateTableName(tableName: TableName): TableName {
-  if (tableName.length <= 2 && tableName.length > 0) return tableName;
+  if (tableName.length <= 3 && tableName.length > 0) return tableName;
   else throw new Error(`${tableName.join(".")} is not a valid table`);
 }
 
@@ -374,14 +374,30 @@ function n1ql_query(
   wOrder: OrderBy | null,
   logger: FastifyBaseLogger
 ): string {
-  const tableAlias = validateTableName(tableName).map((str: string) => str.toLowerCase()).join("_");
-  const scopeName = tableName.at(0) || '_default';
-  const collectionName = tableName.at(1) || '_default';
+  const tableAlias = validateTableName(tableName)[2];
+  const scopeName = tableName.at(0) || "_default";
+  const collectionName = tableName.at(1) || "_default";
   const from = `\`${config.bucket}\`.\`${scopeName}\`.\`${collectionName}\``;
-  const n1qlQuery = isEmptyObject(fields) ? '' : (() => {
-    const innerFromClauses = `${let_relationss(fields, tableName, tableAlias, ts, config, logger)} ${where(wWhere, tableAlias, logger)} ${order(wOrder, tableAlias)} ${limit(wLimit)} ${offset(wOffset)}`;
-    return `SELECT ${select_fields(fields, tableName, ts)} FROM ${from} AS ${tableAlias} ${innerFromClauses}`;
-  })()
+  const n1qlQuery = isEmptyObject(fields)
+    ? ""
+    : (() => {
+        const innerFromClauses = `${let_relationss(
+          fields,
+          tableName,
+          tableAlias,
+          ts,
+          config,
+          logger
+        )} ${where(wWhere, tableAlias, logger)} ${order(
+          wOrder,
+          tableAlias
+        )} ${limit(wLimit)} ${offset(wOffset)}`;
+        return `SELECT ${select_fields(
+          fields,
+          tableName,
+          ts
+        )} FROM ${from} AS ${tableAlias} ${innerFromClauses}`;
+      })();
   logger.info(`Converter expression to query ${n1qlQuery}`);
   return tag("n1ql_query", `${n1qlQuery}`);
 }
@@ -542,8 +558,10 @@ function aggregates_query(
 ): string {
   if (isEmptyObject(aggregates)) return "";
 
-  const tableAlias = validateTableName(tableName).map((str: string) => str.toLowerCase()).join("_");
-  const from = `\`${config.bucket}\`.\`${config.scope}\`.\`${config.collection}\``;
+  const tableAlias = validateTableName(tableName)[2];
+  const scopeName = tableName.at(0) || "_default";
+  const collectionName = tableName.at(1) || "_default";
+  const from = `\`${config.bucket}\`.\`${scopeName}\`.\`${collectionName}\``;
 
   const whereClause = where(wWhere, tableAlias, logger);
 
@@ -681,10 +699,17 @@ function defaultObject(request: QueryRequest) {
  * @param logger instance of fastify logger
  *
  */
-export async function queryData(cluster: Cluster, queryRequest: QueryRequest, config: Config, logger: FastifyBaseLogger): Promise<QueryResponse | ErrorResponse> {
+export async function queryData(
+  cluster: Cluster,
+  queryRequest: QueryRequest,
+  config: Config,
+  logger: FastifyBaseLogger
+): Promise<QueryResponse | ErrorResponse> {
   logger.debug(queryRequest, "Query request");
   const q = query(queryRequest, config, logger);
   const q_aggregate = aggregateQuery(queryRequest, config, logger);
+  const tableName = queryRequest.table;
+  const scopeName = tableName.at(0);
 
   const query_length_limit = envToNum("QUERY_LENGTH_LIMIT", Infinity);
   if (q.length > query_length_limit) {
@@ -705,11 +730,20 @@ export async function queryData(cluster: Cluster, queryRequest: QueryRequest, co
         ? toParameters(queryRequest.query.where, logger)
         : {};
       const bucket = cluster.bucket(config.bucket);
-      const result = q.length > 0 ? await bucket.scope(config.scope ?? 'default').query(q, {parameters: parameters}) : null;
-      const aggregate_result = q_aggregate.length > 0 ? await bucket.scope(config.scope ?? 'default').query(q_aggregate) : null;
-      return output(result, defaultObject(queryRequest), aggregate_result);
-    }
-    catch (ex) {
+      const result =
+        q.length > 0
+          ? await bucket
+              .scope(scopeName ?? "_default")
+              .query(q, { parameters: parameters })
+          : undefined;
+      const aggregate_result =
+        q_aggregate.length > 0
+          ? await bucket
+              .scope(scopeName ?? "_default")
+              .query(q_aggregate, { parameters: parameters })
+          : undefined;
+      return output(defaultObject(queryRequest), result, aggregate_result);
+    } catch (ex) {
       logger.error(ex, `captured.exception`);
       if (ex instanceof IndexFailureError) {
         return {

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,74 +1,118 @@
-import { ColumnInfo, Constraint, SchemaResponse, TableInfo } from "@hasura/dc-api-types";
+import {
+  ColumnInfo,
+  Constraint,
+  SchemaResponse,
+  TableInfo,
+} from "@hasura/dc-api-types";
 import { Cluster } from "couchbase";
 import { Config } from "./config";
+import { tableNameEquals } from "./utils";
 
-const inferQuery = (bucket: string, scope: string, collection: string): string => {
+const inferQuery = (
+  bucket: string,
+  scope: string,
+  collection: string
+): string => {
   return `INFER \`${bucket}\`.\`${scope}\`.\`${collection}\``;
-}
+};
 
-export async function getSchema(config: Config, cluster: Cluster, logger: any): Promise<SchemaResponse> {
-
+export async function getSchema(
+  config: Config,
+  cluster: Cluster,
+  logger: any
+): Promise<SchemaResponse> {
   const tables: TableInfo[] = [];
-  let result = await cluster.query(inferQuery(config.bucket, config.scope, config.collection));
-  let schemaInfo = result.rows[0];
+  let scopes = await cluster.bucket(config.bucket).collections().getAllScopes();
 
-  for (const k in schemaInfo) {
-    let properties = schemaInfo[k].properties;
-    let columns: ColumnInfo[] = [{
-      name: 'id',
-      nullable: false,
-      type: 'string',
-    }];
+  console.log(scopes);
+  for (const scope of scopes) {
+    for (const collection of scope.collections) {
+      let result;
+      const tname = [scope.name, collection.name];
 
-    for (const key in properties) {
-      let type = properties[key].type;
-      let nullable = false;
-      if (properties[key].type instanceof Array) {
-        let index = properties[key].type.indexOf("null");
-        if (index != -1) {
-          nullable = true;
-          properties[key].type.splice(index, 1);
-          type = properties[key].type[0];
-          logger.debug(type);
+      for (const table of tables) {
+        if (tableNameEquals(table.name)(tname)) {
+          continue;
         }
       }
 
-      columns.push({
-        name: key,
-        nullable: nullable,
-        type: type,
-      });
+      try {
+        result = await cluster.query(
+          inferQuery(config.bucket, scope.name, collection.name)
+        );
+      } catch (error) {
+        // Ignore error infers
+        continue;
+      }
+
+      let schemaInfo = result.rows.at(0);
+
+      for (const collectionMetadata of schemaInfo) {
+        let properties = collectionMetadata.properties;
+        let columns: ColumnInfo[] = [
+          {
+            name: "id",
+            nullable: false,
+            type: "string",
+          },
+        ];
+
+        for (const key in properties) {
+          let type = properties[key].type;
+          let nullable = false;
+          if (properties[key].type instanceof Array) {
+            let index = properties[key].type.indexOf("null");
+            if (index != -1) {
+              nullable = true;
+              properties[key].type.splice(index, 1);
+              type = properties[key].type[0];
+              logger.debug(type);
+            }
+          }
+
+          columns.push({
+            name: key,
+            nullable: nullable,
+            type: type,
+          });
+        }
+
+        let tinfo = config.documents?.filter(
+          (doc) =>
+            doc.name.toLocaleLowerCase() == tname.join(".").toLocaleLowerCase()
+        )[0];
+
+        let foreign_keys: [string, Constraint][] = [];
+        if (tinfo?.relations != undefined) {
+          foreign_keys = tinfo!.relations!.flatMap((value) => {
+            return [
+              [
+                `${tname} -> ${value.target_document}`,
+                {
+                  column_mapping: value.field_mapping,
+                  foreign_table: [value.target_document],
+                },
+              ],
+            ];
+          });
+        }
+
+        let foreignKeys: Record<string, Constraint> = {};
+
+        foreign_keys.forEach((value) => (foreignKeys[value[0]] = value[1]));
+
+        let table: TableInfo = {
+          name: tname,
+          columns: columns,
+          primary_key: ["id"],
+          foreign_keys: foreignKeys,
+        };
+        tables.push(table);
+      }
     }
-
-    const tname = properties.type.samples.map((str: any) => str.charAt(0).toUpperCase() + str.slice(1));
-    let tinfo = config.documents?.filter((doc) => doc.name.toLocaleLowerCase() == tname.join(".").toLocaleLowerCase())[0];
-
-    let foreign_keys :  [string, Constraint][] = [];
-    if (tinfo?.relations != undefined) {
-      foreign_keys = tinfo!.relations!.flatMap((value) => {
-        return [[
-          `${tname} -> ${value.target_document}`,
-        {
-            column_mapping: value.field_mapping,
-            foreign_table: [value.target_document],
-        }]];
-      });
-    }
-
-    let foreignKeys :  Record<string, Constraint> = {};
-
-    foreign_keys.forEach(value => foreignKeys[value[0]] = value[1]);
-    
-    let table: TableInfo = {
-      name: tname,
-      columns: columns,
-      primary_key: ["id"],
-      foreign_keys: foreignKeys,
-    }
-    tables.push(table)
   }
 
   return {
-    tables: tables
+    tables: tables,
   };
-};
+}


### PR DESCRIPTION
* Fixes parameters for aggregate queries not working
* Reworks support for scopes and collections
* Adds new E2E tests to test scopes and collections
* Edit Getting Started to reflect new changes
* New table names are in the format ["scopeName", "collectionName", "documentFlavorType"]

A query like:

```
FROM `travel-sample`.`_default`.`_default` ... type = 'airline'
```

would translate to a Table with the name `["_default","_default","airline"]` on the Hasura side (or `_default__default_airline` on the Hasura console)

